### PR TITLE
Improving scripts in datasets and run_scripts directories

### DIFF
--- a/datasets/imagenet/build_imagenet_data.pbs
+++ b/datasets/imagenet/build_imagenet_data.pbs
@@ -1,65 +1,33 @@
 #!/bin/bash
 
-### set the number of processing elements (PEs) or cores
-### set the number of PEs per node
 #PBS -l nodes=16:ppn=1:xk
-### set the wallclock time
 #PBS -l walltime=02:00:00
-### set the job name
 #PBS -N BuildImageNetTFRecords
-### set the job stdout and stderr
 #PBS -e logs/log.${PBS_JOBNAME}_${PBS_JOBID}.err
 #PBS -o logs/log.${PBS_JOBNAME}_${PBS_JOBID}.out
-### set email notification
-##PBS -m bea
-##PBS -M nowhere@illinois.edu
-### In case of multiple allocations, select which one to charge
-##PBS -A xyz
 
-# NOTE: lines that begin with "#PBS" are not interpreted by the shell but ARE 
-# used by the batch system, wheras lines that begin with multiple # signs, 
-# like "##PBS" are considered "commented out" by the batch system 
-# and have no effect.  
+## For more options, consult https://bluewaters.ncsa.illinois.edu/batch-jobs
 
-# If you launched the job in a directory prepared for the job to run within, 
-# you'll want to cd to that directory
-# [uncomment the following line to enable this]
 cd $PBS_O_WORKDIR
 
-# Alternatively, the job script can create its own job-ID-unique directory 
-# to run within.  In that case you'll need to create and populate that 
-# directory with executables and perhaps inputs
-# [uncomment and customize the following lines to enable this behavior] 
-# mkdir -p /scratch/sciteam/$USER/$PBS_JOBID
-# cd /scratch/sciteam/$USER/$PBS_JOBID
-# cp /scratch/job/setup/directory/* .
-
-# To add certain modules that you do not have added via ~/.modules 
-#. /opt/modules/default/init/bash
-#module load craype-hugepages2M  perftools
-
-### launch the application
-### redirecting stdin and stdout if needed
-### NOTE: (the "in" file must exist for input)
-
-module load bwpy/0.3.0
+module load bwpy/0.3.1
 module load tensorflow
 
 echo "Starting"
+
 MODE="train"
 #MODE="validation"
-
 
 RAW_DATA_DIR="${HOME}/scratch/ImageNet/raw-imagenet/$MODE"
 DATA_LIST_FILE="${MODE}_files.txt"
 META_DATA_FILE="$PBS_O_WORKDIR/../../models/research/inception/inception/data/imagenet_metadata.txt"
 OUTPUT_DIR="${HOME}/scratch/ImageNet/tf_records/${MODE}"
-mkdir -p ${HOME}/scratch/ImageNet
-mkdir -p ${HOME}/scratch/ImageNet/tf_records
-
 LOG_DIR="logs/build_imagenet_data_${PBS_JOBID}"
 
-# make sure you qsub this script from the same directoy
+mkdir -p ${HOME}/scratch/ImageNet/tf_records
+mkdir -p $LOG_DIR
+
+# make sure to submit this script to the queue from the directoy
 # that build_imagenet_data.pbs is in.
 NUM_DIV=$(cat $PBS_NODEFILE | wc -l)
 
@@ -77,18 +45,18 @@ let r=$NUM_DIV-1
 
 TOT_LENGTH=$(wc -l $DATA_LIST_FILE | cut -d " " -f1)
 
-mkdir -p $LOG_DIR
-
-echo "Removing existing output directory and its contents: ${OUTPUT_DIR}"
-rm -rf $OUTPUT_DIR
+if [[ -d $OUTPUT_DIR ]]; then
+    echo "Removing existing output directory and its contents: $OUTPUT_DIR"
+    rm -rf $OUTPUT_DIR
+    echo "Finished removing existing output directory and its contents: ${OUTPUT_DIR}"
+fi
 mkdir $OUTPUT_DIR
-
-echo "Done, Removing existing output directory and its contents: ${OUTPUT_DIR}"
 
 BB_RUN_SCRIPT=do_bb.sh
 TF_RUN_SCRIPT=do_tf.sh
 
-cat <<EOF>$BB_RUN_SCRIPT
+
+cat > $BB_RUN_SCRIPT << EOF
 #!/bin/bash
 
 set -e
@@ -108,15 +76,13 @@ echo "Starting BBox">  $LOG_DIR/\${PBS_JOBNAME}_index_\${index}_of_${NUM_DIV}_jo
 
 echo "done BBox" >>  $LOG_DIR/\${PBS_JOBNAME}_index_\${index}_of_${NUM_DIV}_jobid_\${PBS_JOBID}.err
 echo "done BBox" >>  $LOG_DIR/\${PBS_JOBNAME}_index_\${index}_of_${NUM_DIV}_jobid_\${PBS_JOBID}.out
-
 EOF
 
 chmod u=rwx $BB_RUN_SCRIPT
+echo "Executing aprun -b -n $PBS_NUM_NODES -N 1 -- $BB_RUN_SCRIPT"
+aprun -b -n $PBS_NUM_NODES -N 1 -- $BB_RUN_SCRIPT
 
-echo "Doing aprun -b -n 16 -N 1 -- $BB_RUN_SCRIPT "
-aprun -b -n 16 -N 1 -- $BB_RUN_SCRIPT
-
-cat <<EOF>$TF_RUN_SCRIPT
+cat > $TF_RUN_SCRIPT << EOF
 #!/bin/bash
 
 set -e
@@ -138,12 +104,8 @@ echo "done tf_record" >>  $LOG_DIR/\${PBS_JOBNAME}_index_\${index}_of_${NUM_DIV}
 echo "done tf_record" >>  $LOG_DIR/\${PBS_JOBNAME}_index_\${index}_of_${NUM_DIV}_jobid_\${PBS_JOBID}.out
 EOF
 
-
 chmod u=rwx $TF_RUN_SCRIPT
+echo "Executing aprun -b -n $PBS_NUM_NODES -N 1 -- $TF_RUN_SCRIPT"
+aprun -b -n $PBS_NUM_NODES -N 1 -- $TF_RUN_SCRIPT
 
-echo "Doing aprun -b -n 16 -N 1 -- $TF_RUN_SCRIPT "
-aprun -b -n 16 -N 1 -- $TF_RUN_SCRIPT
-
-echo "Done, thank you for flying."
-
-### For more information see the man page for aprun
+echo "Done!"

--- a/datasets/imagenet/extract_data_from_archive.pbs
+++ b/datasets/imagenet/extract_data_from_archive.pbs
@@ -1,50 +1,19 @@
 #!/bin/bash
 
-### set the number of processing elements (PEs) or cores
-### set the number of PEs per node
 #PBS -l nodes=2:ppn=32:xe
-### set the wallclock time
 #PBS -l walltime=08:00:00
-### set the job name
 #PBS -N ExtractImageNetDataFromArchive
-### set the job stdout and stderr
 #PBS -e logs/log.${PBS_JOBNAME}_${PBS_JOBID}.err
 #PBS -o logs/log.${PBS_JOBNAME}_${PBS_JOBID}.out
-### set email notification
-##PBS -m bea
-##PBS -M nowhere@illinois.edu
-### In case of multiple allocations, select which one to charge
-##PBS -A xyz
 
-# NOTE: lines that begin with "#PBS" are not interpreted by the shell but ARE 
-# used by the batch system, wheras lines that begin with multiple # signs, 
-# like "##PBS" are considered "commented out" by the batch system 
-# and have no effect.  
+## For more options, consult https://bluewaters.ncsa.illinois.edu/batch-jobs
 
-# If you launched the job in a directory prepared for the job to run within, 
-# you'll want to cd to that directory
-# [uncomment the following line to enable this]
 cd $PBS_O_WORKDIR
-# Alternatively, the job script can create its own job-ID-unique directory 
-# to run within.  In that case you'll need to create and populate that 
-# directory with executables and perhaps inputs
-# [uncomment and customize the following lines to enable this behavior] 
-# mkdir -p /scratch/sciteam/$USER/$PBS_JOBID
-# cd /scratch/sciteam/$USER/$PBS_JOBID
-# cp /scratch/job/setup/directory/* .
-
-# To add certain modules that you do not have added via ~/.modules 
-#. /opt/modules/default/init/bash
-#module load craype-hugepages2M  perftools
-
-### launch the application
-### redirecting stdin and stdout if needed
-### NOTE: (the "in" file must exist for input)
 
 IMAGENET_IMAGE_TAR_ARCHIVE=/sw/unsupported/mldata/ImageNet/Images.tar
 IMAGENET_ANNOTATION_TAR_ARCHIVE=/sw/unsupported/mldata/ImageNet/Annotation.tar.gz
 
-# keep debuging, training, validation, and  testing data in differnt dir
+# keep debuging, training, validation, and testing data in differnt directories
 # choose which you are doing here
 MODE=training
 #MODE=validation
@@ -54,13 +23,12 @@ FILE_LIST=$PBS_O_WORKDIR/${MODE}_files.txt
 #FILE_LIST=$PBS_O_WORKDIR/validation_files.txt
 #FILE_LIST=$PBS_O_WORKDIR/testing_files.txt
 
-mkdir -p ${HOME}/scratch/ImageNet
 mkdir -p ${HOME}/scratch/ImageNet/raw-imagenet
 DEST_DIR=${HOME}/scratch/ImageNet/raw-imagenet/$MODE
 
 IMG_DEST_DIR=$DEST_DIR/Images
 # ANN_DEST_DIR=$DEST_DIR/Annotations
-# You might have though it should been the above, but the tarball already has a subdrectory Annotation
+# You might have thought it should've been the above, but the tarball already has a subdrectory Annotation
 ANN_DEST_DIR=$DEST_DIR
 
 echo "Romoveing and creating $DEST_DIR. If there is old data in the directory, it might take a while."
@@ -72,12 +40,9 @@ mkdir -p $ANN_DEST_DIR
 export LOG_DIR="logs/extract_data_from_archive_${PBS_JOBID}"
 
 echo "Starting. You have set the following env var"
-
 echo "IMAGENET_IMAGE_TAR_ARCHIVE=$IMAGENET_IMAGE_TAR_ARCHIVE"
 echo "IMAGENET_ANNOTATION_TAR_ARCHIVE=$IMAGENET_ANNOTATION_TAR_ARCHIVE"
-
 echo "DEST_DIR=$DEST_DIR"
-
 echo "FILE_LIST=$FILE_LIST"
 
 module load bwpy/0.3.1
@@ -95,16 +60,12 @@ IMG_SYNSET_LIST=($(python -c "with open(\"${FILE_LIST}\") as f:
     for i in list(set([l.strip().split(' ')[1].split('_')[0] for l in f])):
         print i"))
 echo "Finished Creating Image Synset list"
-
 let TOT_SYNSET=${#IMG_SYNSET_LIST[@]}
-
 echo "Total Number of Synset $TOT_SYNSET"
-
 echo "Converting Validation Data"
 
 IMAGE_RUN_SCRIPT=extract_images.sh
-
-cat <<EOF>$IMAGE_RUN_SCRIPT
+cat > $IMAGE_RUN_SCRIPT << EOF
 #!/bin/bash
 
 index=\$ALPS_APP_PE
@@ -118,34 +79,29 @@ for syn in \$SYNSET_SLICE
 do
 
 IMAGES_LIST=\$( python -c "with open(\"${FILE_LIST}\") as f:
-    for i in [l.strip().split(\" \")[1] + '.JPEG' for l in f if \"\${syn}\" in l.split()[1] ]: 
+    for i in [l.strip().split(\" \")[1] + '.JPEG' for l in f if \"\${syn}\" in l.split()[1] ]:
         print i" )
 
 echo "\${index}: starting tar -xf ${IMAGENET_IMAGE_TAR_ARCHIVE} --to-stdout \${syn}.tar | tar -x -C ${IMG_DEST_DIR} \${IMAGES_LIST}"
 tar -xf ${IMAGENET_IMAGE_TAR_ARCHIVE} --to-stdout \${syn}.tar | tar -x -C ${IMG_DEST_DIR} \${IMAGES_LIST}
 
 done
-
 EOF
 
 chmod u=rwx $IMAGE_RUN_SCRIPT
-
 echo "Doing aprun -b -n 32 -N 16 -- map.sh $IMAGE_RUN_SCRIPT $NUM_DIV [...]"
-
 aprun -b -n 64 -N 32 -- map.sh $IMAGE_RUN_SCRIPT $NUM_DIV ${IMG_SYNSET_LIST[@]}
-
-echo "Done with images, Wrote data to ${IMG_DEST_DIR}"
+echo "Done with images, Wrote data to $IMG_DEST_DIR"
 echo "Starting Annotation extraction"
-
 echo "Creating Annotation Synset list"
-ANN_SYNSET_LIST=($(python -c "with open(\"${FILE_LIST}\") as f:
+ANN_SYNSET_LIST=($(python -c "with open(\"$FILE_LIST\") as f:
     for i in list(set([l.strip().split(' ')[0] for l in f])):
         print i"))
 echo "Finished Creating Annotatios Synset list"
 
 ANN_RUN_SCRIPT=extract_Annotations.sh
-
-cat <<EOF>$ANN_RUN_SCRIPT
+cat > $ANN_RUN_SCRIPT << EOF
+#!/bin/bash
 
 index=\$ALPS_APP_PE
 echo "\$index: starting $ANN_RUN_SCRIPT"
@@ -158,23 +114,19 @@ for syn in \$SYNSET_SLICE
 do
 
 XML_LIST=\$( python -c "import os
-with open(\"${FILE_LIST}\") as f:
-    for i in [os.path.join(\"Annotation\", *l.strip().split(\" \")) + '.xml' for l in f if \"\${syn}\" in l.split(\" \")[0]]:
+with open(\"$FILE_LIST\") as f:
+    for i in [os.path.join(\"Annotation\", *l.strip().split(\" \")) + '.xml' for l in f if \"\$syn\" in l.split(\" \")[0]]:
         print i" )
 
-echo "\${index}: starting tar -xzf $IMAGENET_ANNOTATION_TAR_ARCHIVE --to-stdout \${syn}.tar.gz | tar -xz -C ${ANN_DEST_DIR} \${XML_LIST}"
-tar -xzf $IMAGENET_ANNOTATION_TAR_ARCHIVE --to-stdout \${syn}.tar.gz | tar -xz -C ${ANN_DEST_DIR} \${XML_LIST}
+echo "\$index: starting tar -xzf $IMAGENET_ANNOTATION_TAR_ARCHIVE --to-stdout \$syn.tar.gz | tar -xz -C $ANN_DEST_DIR \$XML_LIST"
+tar -xzf $IMAGENET_ANNOTATION_TAR_ARCHIVE --to-stdout \$syn.tar.gz | tar -xz -C $ANN_DEST_DIR \${XML_LIST}
 
 done
-
 EOF
 
 chmod u=rwx $ANN_RUN_SCRIPT
-
 echo "Doing aprun -b -n 32 -N 16 -- map.sh $ANN_RUN_SCRIPT $NUM_DIV [...]"
-
 aprun -b -n 64 -N 32 -- map.sh $ANN_RUN_SCRIPT $NUM_DIV ${ANN_SYNSET_LIST[@]}
-
 echo "Done with annotations, Wrote data to ${ANN_DEST_DIR}"
 
 rm $ANN_RUN_SCRIPT

--- a/datasets/imagenet/map.sh
+++ b/datasets/imagenet/map.sh
@@ -1,22 +1,18 @@
 #!/bin/bash
 
-if [ -z "${1}" ]
-then
-echo "Usage <my_script.sh> <total num of nodes> [list of tokens]"
-exit 1
+if [[ -z "$1" ]]; then
+    echo "Usage: <script.sh> <total num of nodes> [list of tokens]"
+    exit 1
 fi
 
-MY_SCRIPT=${1}
-shift
-NUM_DIV=${1}
-shift
+MY_SCRIPT=$1; shift
+NUM_DIV=$1; shift
 
-if [ ! -z "$*" ]
-then
-TOT_LIST=($*)
+if [[ ! -z "$*" ]]; then 
+    TOT_LIST=($*)
 else
-read tmp
-TOT_LIST=($tmp)
+    read tmp
+    TOT_LIST=($tmp)
 fi
 
 let NUM_LIST=${#TOT_LIST[@]}
@@ -31,12 +27,12 @@ index=$ALPS_APP_PE
 
 if [ "$index" -ge "$step_remainder" ]
 then
-let exes=$index-$step_remainder
-let a=$step_block*$step_remainder+$step_remainder+$step_block*exes
-let b=$step_block
+    let exes=$index-$step_remainder
+    let a=$step_block*$step_remainder+$step_remainder+$step_block*$exes
+    let b=$step_block
 else
-let a=$step_block*$index+$index
-let b=$step_block+1
+    let a=$step_block*$index+$index
+    let b=$step_block+1
 fi
 
 LIST_SLICE="${TOT_LIST[@]:$a:$b}"

--- a/run_scripts/README.md
+++ b/run_scripts/README.md
@@ -1,2 +1,2 @@
-distributed_tf_launch.pbs is a skeleton script that runs a given distributed
-Tensorflow app. At the moment it's wired up to run [benchmark_cnn.py](https://github.com/tensorflow/benchmarks/blob/master/scripts/tf_cnn_benchmarks/benchmark_cnn.py)
+`distributed_tf_launch.pbs` is a skeleton script that runs a given distributed Tensorflow app.
+At the moment it's wired up to run [benchmark_cnn.py](https://github.com/tensorflow/benchmarks/blob/master/scripts/tf_cnn_benchmarks/benchmark_cnn.py)

--- a/run_scripts/dist.sh
+++ b/run_scripts/dist.sh
@@ -1,27 +1,20 @@
 #!/bin/bash
 cd $PBS_O_WORKDIR
 
-WORKER_HOSTS_TASKS=${1}
-shift
-PS_HOSTS_TASKS=${1}
-shift
-DATA_DIR=${1}
-shift
-TRAIN_DIR=${1}
-shift
+WORKER_HOSTS_TASKS=$1;
+PS_HOSTS_TASKS=$2;
+DATA_DIR=$3;
+TRAIN_DIR=$4;
+
+shift 4
 
 CMD_ARGS=${*}
-
 CMD_LOC="../benchmarks/scripts/tf_cnn_benchmarks/"
-
 MY_HOST_NAME=$(hostname)
-
 WORKER_HOSTS=""
 PS_HOSTS=""
-
 WHAT_AM_I=""
 MY_TASK_NUMBER=""
-
 WORKER_WAIT_TIME=20
 
 for h in $(echo $WORKER_HOSTS_TASKS | sed "s/,/ /g")
@@ -64,7 +57,7 @@ PY_CMD="${CMD_LOC}/tf_cnn_benchmarks.py \
 --task_index ${MY_TASK_NUMBER} \
 ${CMD_ARGS}"
 
-echo "I am ${MY_HOST_NAME}, my job is ${WHAT_AM_I} with task id ${MY_TASK_NUMBER}. Im about to run
+echo "Hi! I am ${MY_HOST_NAME}. My job is: ${WHAT_AM_I} with task id: ${MY_TASK_NUMBER}. I'm about to run
 python ${PY_CMD}"
 
 python $PY_CMD

--- a/run_scripts/distributed_tf_launch.pbs
+++ b/run_scripts/distributed_tf_launch.pbs
@@ -1,78 +1,46 @@
 #!/bin/bash
 
-### set the number of processing elements (PEs) or cores
-### set the number of PEs per node
 #PBS -l nodes=16:ppn=1:xk
-### set the wallclock time
 #PBS -l walltime=02:00:00
-### set the job name
 #PBS -N distributed_tf_launch
-### set the job stdout and stderr
 #PBS -e logs/log.${PBS_JOBNAME}_${PBS_JOBID}.err
 #PBS -o logs/log.${PBS_JOBNAME}_${PBS_JOBID}.out
-### set email notification
-##PBS -m bea
-##PBS -M nowhere@illinois.edu
-### In case of multiple allocations, select which one to charge
-##PBS -A xyz
 
-# NOTE: lines that begin with "#PBS" are not interpreted by the shell but ARE 
-# used by the batch system, wheras lines that begin with multiple # signs, 
-# like "##PBS" are considered "commented out" by the batch system 
-# and have no effect.  
+## For more options, consult https://bluewaters.ncsa.illinois.edu/batch-jobs
 
-# If you launched the job in a directory prepared for the job to run within, 
-# you'll want to cd to that directory
-# [uncomment the following line to enable this]
 cd $PBS_O_WORKDIR
-
-# Alternatively, the job script can create its own job-ID-unique directory 
-# to run within.  In that case you'll need to create and populate that 
-# directory with executables and perhaps inputs
-# [uncomment and customize the following lines to enable this behavior] 
-# mkdir -p /scratch/sciteam/$USER/$PBS_JOBID
-# cd /scratch/sciteam/$USER/$PBS_JOBID
-# cp /scratch/job/setup/directory/* .
-
-# To add certain modules that you do not have added via ~/.modules 
-#. /opt/modules/default/init/bash
-#module load craype-hugepages2M  perftools
-
-### launch the application
-### redirecting stdin and stdout if needed
-### NOTE: (the "in" file must exist for input)
 
 module load bwpy/0.3.1
 
 NUM_BATCHES=100
 DATA_DIR="${HOME}/scratch/ImageNet/tf_records"
-TRAIN_DIR="train_dir" # This directory is where the tf graph and checkpoint is saved
+TRAIN_DIR="train_dir" # Directory where TensorFlow saves graphs and checkpoints
 NUM_PS_HOSTS=1
 
-DO_TRAIN_VAL="--data_dir ${DATA_DIR}/train"
-#DO_TRAIN_VAL="--data_dir ${DATA_DIR}/validation --eval"
+DO_TRAIN_VAL="--data_dir $DATA_DIR/train"
+#DO_TRAIN_VAL="--data_dir $DATA_DIR/validation --eval"
 
-HOST_NAMES=$(aprun -q -n ${PBS_NUM_NODES} -N ${PBS_NUM_PPN} -- hostname)
+HOST_NAMES=$(aprun -q -n $PBS_NUM_NODES -N 1 -- hostname)
 let PS_HOST_COUNT=0
 let WORKER_HOST_COUNT=0
 
 PS_HOSTS_TASKS=""
 WORKER_HOSTS_TASKS=""
 
-for hn in $HOST_NAMES
+for host_name in $HOST_NAMES
 do
     if [ $PS_HOST_COUNT -lt $NUM_PS_HOSTS ]
     then
-	PS_HOSTS_TASKS="${hn}:$PS_HOST_COUNT,${PS_HOSTS_TASKS}" # , and : are delimiters
+	PS_HOSTS_TASKS="$host_name:$PS_HOST_COUNT,$PS_HOSTS_TASKS" # , and : are delimiters
 	let PS_HOST_COUNT++
     else
-	WORKER_HOSTS_TASKS="${hn}:${WORKER_HOST_COUNT},${WORKER_HOSTS_TASKS}" # , and : are delimiters
+	WORKER_HOSTS_TASKS="$host_name:$WORKER_HOST_COUNT,$WORKER_HOSTS_TASKS" # , and : are delimiters
 	let WORKER_HOST_COUNT++
     fi
 done
 
-WORKER_HOSTS_TASKS=$(echo $WORKER_HOSTS_TASKS | sed 's/,$//')
-PS_HOSTS_TASKS=$(echo $PS_HOSTS_TASKS | sed 's/,$//')
+WORKER_HOSTS_TASKS=$(sed 's|,$||' <<< $WORKER_HOSTS_TASKS)
+PS_HOSTS_TASKS=$(sed 's|,$||' <<< $PS_HOSTS_TASKS)
 
 RUN_CMD="${PBS_O_WORKDIR}/dist.sh"
 # parameter_server \
@@ -91,7 +59,7 @@ ADDITIONAL_ARGS="--batch_size 32 \
 --num_intra_threads 1 \
 --num_inter_threads 0"
 
-RUN_ARGUMENTS="${WORKER_HOSTS_TASKS} ${PS_HOSTS_TASKS} ${DATA_DIR} ${TRAIN_DIR} ${ADDITIONAL_ARGS} ${DO_TRAIN_VAL}" 
+RUN_ARGUMENTS="${WORKER_HOSTS_TASKS} ${PS_HOSTS_TASKS} ${DATA_DIR} ${TRAIN_DIR} ${ADDITIONAL_ARGS} ${DO_TRAIN_VAL}"
 
 echo "Running $RUN_CMD $RUN_ARGUMENTS"
 
@@ -99,5 +67,3 @@ aprun -b -n ${PBS_NUM_NODES} -N ${PBS_NUM_PPN} -- $RUN_CMD $RUN_ARGUMENTS \
     1> $PBS_O_WORKDIR/logs/${PBS_JOBNAME}_${PBS_JOBID}.out \
     2> $PBS_O_WORKDIR/logs/${PBS_JOBNAME}_${PBS_JOBID}.err
 echo "Done, thank you for flying."
-
-### For more information see the man page for aprun


### PR DESCRIPTION
- Removing some extraneous comments
- Using `bwpy/0.3.1` in `datasets/imagenet/build_imagenet_data.pbs`
- Using `1` instead of `$PBS_NUM_PPN` in `run_scripts/distributed_tf_launch.pbs` to obtain the list of nodes.